### PR TITLE
Remove export statement from font declaration

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,7 @@ import Link from "next/link"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 
-export const fontSans = FontSans({
+const fontSans = FontSans({
   subsets: ["latin"],
   variable: "--font-sans",
 })


### PR DESCRIPTION
Font cannot be exported from the layout file, fixing misdirection from shadcn setup docs.